### PR TITLE
Code Generation support for `exit <int>` statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ c:
 # Basically all the flags should be written before the positional argument because of 
 # Go's flag package's internal working. That's why -d after assets/code.tk won't work
 r:
-	./bin/tarkac -d assets/code.tk
+	./bin/tarkac -d -f assets/code.asm -o assets/code assets/code.tk
 
 # Basically, to view docs in an HTML view
 d:

--- a/internal/asmgen/lnx64/lnx64.go
+++ b/internal/asmgen/lnx64/lnx64.go
@@ -1,0 +1,65 @@
+// Package lnx64 contains the code generation functions for IR to lnx64 FASM
+package lnx64
+
+import (
+	"fmt"
+
+	"github.com/adinovap20/tarkac/internal/ir"
+)
+
+// Generator structure for generating the FASM code
+type Generator struct {
+	Code string // Code holds the generated FASM code
+}
+
+// NewGenerator creates and returns a new instance of Generator
+func NewGenerator() *Generator {
+	return &Generator{Code: ""}
+}
+
+// addInst adds the instruction in the FASM code
+func (g *Generator) addInst(inst string) {
+	g.Code += inst + "\n"
+}
+
+// addIndentedInst adds the indented instruction in the FASM code.
+func (g *Generator) addIndentedInst(inst string) {
+	g.Code += "    " + inst + "\n"
+}
+
+// addBlankLine adds the blank line in the FASM code
+func (g *Generator) addBlankLine() {
+	g.Code += "\n"
+}
+
+// VisitIRProgram visits the IRProgram node and generates lnx64 FASM code.
+func (g *Generator) VisitIRProgram(p *ir.IRProgram) {
+	g.addInst("format ELF64 executable 3")
+	g.addInst("entry start")
+	g.addBlankLine()
+	g.addInst("segment readable executable")
+	g.addBlankLine()
+	g.addInst("start:")
+	for _, inst := range p.Insts {
+		inst.Accept(g)
+	}
+}
+
+// VisitIRLoadInt visits the IRLoadInt node and generates lnx64 FASM code.
+func (g *Generator) VisitIRLoadInt(i *ir.IRLoadInt) {
+	instComment := fmt.Sprintf("; --- LOAD INT %d ---", i.Val)
+	inst := fmt.Sprintf("push %d", i.Val)
+	g.addIndentedInst(instComment)
+	g.addIndentedInst(inst)
+	g.addBlankLine()
+}
+
+// VisitIRExit visits the IRExit node and generates lnx64 FASM code.
+func (g *Generator) VisitIRExit(i *ir.IRExit) {
+	instComment := "; --- EXIT ---"
+	g.addIndentedInst(instComment)
+	g.addIndentedInst("mov rax, 60")
+	g.addIndentedInst("pop rdi")
+	g.addIndentedInst("syscall")
+	g.addBlankLine()
+}

--- a/internal/ir/model.go
+++ b/internal/ir/model.go
@@ -6,6 +6,7 @@ import "strconv"
 // IRInstruction interface for all the IR nodes
 type IRInstruction interface {
 	String() string // Returns the string representation
+	Accept(v Visitor)
 }
 
 // IRProgram structure holds the IR as a program
@@ -22,6 +23,11 @@ func (p *IRProgram) String() string {
 	return str
 }
 
+// Accept visits the IRProgram
+func (p *IRProgram) Accept(v Visitor) {
+	v.VisitIRProgram(p)
+}
+
 // IRLoadInt structure holds the IR for `LOAD INT <int>` instruction
 type IRLoadInt struct {
 	Val int // Val holds the integer value to be loaded
@@ -32,10 +38,20 @@ func (i *IRLoadInt) String() string {
 	return "LOAD INT " + strconv.Itoa(i.Val)
 }
 
+// Accept visits the IRLoadInt
+func (i *IRLoadInt) Accept(v Visitor) {
+	v.VisitIRLoadInt(i)
+}
+
 // IRExit structure holds the IR for `EXIT` instruction
 type IRExit struct{}
 
 // String returns the string representation of IRExit
 func (i *IRExit) String() string {
 	return "EXIT"
+}
+
+// Accept visits the IRExit
+func (i *IRExit) Accept(v Visitor) {
+	v.VisitIRExit(i)
 }

--- a/internal/ir/visitor.go
+++ b/internal/ir/visitor.go
@@ -1,0 +1,8 @@
+package ir
+
+// Visitor interface for traversing the IR
+type Visitor interface {
+	VisitIRProgram(p *IRProgram)
+	VisitIRLoadInt(i *IRLoadInt)
+	VisitIRExit(i *IRExit)
+}


### PR DESCRIPTION
- Code Generation support for `exit <int>` statement